### PR TITLE
Little improvements to the general usability of the application 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,10 @@ ipch/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 
+# JetBrains Rider
+.idea/
+*.DotSettings
+
 # TeamCity is a build add-in
 _TeamCity*
 

--- a/SPICA.WinForms/Formats/FileIO.cs
+++ b/SPICA.WinForms/Formats/FileIO.cs
@@ -24,8 +24,11 @@ namespace SPICA.WinForms.Formats
 
             int OpenFiles = 0;
 
+            using (FrmLoading Form = new FrmLoading(FileNames.Length))
             foreach (string FileName in FileNames)
             {
+                Form.Proceed(FileName);
+                
                 H3DDict<H3DBone> Skeleton = null;
 
                 if (Scene.Models.Count > 0) Skeleton = Scene.Models[0].Skeleton;

--- a/SPICA.WinForms/FrmLoading.cs
+++ b/SPICA.WinForms/FrmLoading.cs
@@ -1,0 +1,42 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+
+namespace SPICA.WinForms
+{
+    public class FrmLoading : Form
+    {
+        private ProgressBar m_Bar;
+        private Label m_Label;
+
+        private int m_Length;
+        private int m_Counter;
+
+        public FrmLoading(int Length)
+        {
+            m_Bar = new ProgressBar {Dock = DockStyle.Bottom, Maximum = Length - 1, Step = 1};
+            m_Label = new Label {Dock = DockStyle.Top, AutoSize = true, MaximumSize = new Size(400, 0)};
+            m_Length = Length;
+
+            Padding = new Padding(10);
+            Size = new Size(400, 120);
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            Controls.AddRange(new Control[] {m_Label, m_Bar});
+
+            LostFocus += (sender, args) => BringToFront();
+            Closing += (sender, args) => args.Cancel = true;
+
+            CenterToScreen();
+            Show();
+        }
+
+        public void Proceed(string FileName)
+        {
+            Text = "Loading Files... (" + ++m_Counter + "/" + m_Length + ")";
+            m_Label.Text = "Loading \"" + FileName + "\"";
+            m_Bar.PerformStep();
+
+            // Prevents UI from not responding
+            Application.DoEvents();
+        }
+    }
+}

--- a/SPICA.WinForms/FrmMain.Designer.cs
+++ b/SPICA.WinForms/FrmMain.Designer.cs
@@ -849,6 +849,7 @@
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FrmMain_FormClosing);
             this.DragDrop += new System.Windows.Forms.DragEventHandler(this.FrmMain_DragDrop);
             this.DragEnter += new System.Windows.Forms.DragEventHandler(this.FrmMain_DragEnter);
+            this.DragOver += new System.Windows.Forms.DragEventHandler(this.FrmMain_DragEnter);
             this.TopMenu.ResumeLayout(false);
             this.TopMenu.PerformLayout();
             this.AnimControlsPanel.ResumeLayout(false);

--- a/SPICA.WinForms/FrmMain.cs
+++ b/SPICA.WinForms/FrmMain.cs
@@ -135,7 +135,7 @@ namespace SPICA.WinForms
         {
             if (e.Data.GetDataPresent(DataFormats.FileDrop))
             {
-                e.Effect = DragDropEffects.Copy;
+                e.Effect = ModifierKeys.HasFlag(Keys.Alt) ? DragDropEffects.Copy : DragDropEffects.Move;
             }
         }
         
@@ -415,11 +415,13 @@ namespace SPICA.WinForms
             MdlCenter = Vector3.Zero;
 
             Dimension = 100;
+            
+            Translation = new Vector3(0, 0, -200);
 
             Transform =
                 Matrix4.CreateRotationY((float)Math.PI * 0.25f) *
                 Matrix4.CreateRotationX((float)Math.PI * 0.25f) *
-                Matrix4.CreateTranslation(0, 0, -200);
+                Matrix4.CreateTranslation(Translation);
         }
 
         private void UpdateTransforms()

--- a/SPICA.WinForms/FrmMain.cs
+++ b/SPICA.WinForms/FrmMain.cs
@@ -266,8 +266,12 @@ namespace SPICA.WinForms
 
         private void Viewport_Resize(object sender, EventArgs e)
         {
-            Renderer?.Resize(Viewport.Width, Viewport.Height);
-
+            if (Renderer != null)
+            {   
+                Renderer.Resize(Viewport.Width, Viewport.Height);
+                Renderer.Camera.ViewMatrix = Transform;   
+            }
+            
             UpdateViewport();
         }
         #endregion

--- a/SPICA.WinForms/FrmMain.cs
+++ b/SPICA.WinForms/FrmMain.cs
@@ -204,16 +204,14 @@ namespace SPICA.WinForms
             {
                 if ((e.Button & MouseButtons.Left) != 0)
                 {
-                    float X = (float)(((e.X - InitialMov.X) / Width)  * Math.PI);
+                    float X = (float)(((e.X - InitialMov.X) / Width)  * Math.PI * 2);
                     float Y = (float)(((e.Y - InitialMov.Y) / Height) * Math.PI);
 
-                    Transform.Row3.Xyz -= Translation;
-
                     Transform *=
+                        Matrix4.CreateTranslation(-Vector3.UnitZ * Translation.Z) *
+                        Matrix4.CreateFromAxisAngle(Transform.Row1.Xyz, X) *
                         Matrix4.CreateRotationX(Y) *
-                        Matrix4.CreateRotationY(X);
-
-                    Transform.Row3.Xyz += Translation;
+                        Matrix4.CreateTranslation(Vector3.UnitZ * Translation.Z);
                 }
 
                 if ((e.Button & MouseButtons.Right) != 0)

--- a/SPICA.WinForms/SPICA.WinForms.csproj
+++ b/SPICA.WinForms/SPICA.WinForms.csproj
@@ -91,6 +91,7 @@
     <Compile Include="FrmGFTFormat.Designer.cs">
       <DependentUpon>FrmGFTFormat.cs</DependentUpon>
     </Compile>
+    <Compile Include="FrmLoading.cs" />
     <Compile Include="FrmMain.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
- An almost non-blocking progress bar is displayed when loading multiple files.
Making loading files asynchronously was too difficult because shaders are being compiled while loading the file. The compiling had to be done on the main thread so it can't be done on an other thread. Trying to decouple loading from compiling would require a decent amount of refactoring which I wouldn't like to do and other hacks where too messy. 
So I tried this implementation. It works fine when loading files that each don't require much time to load. With very big files the UI still blocks but only while loading these. 
- Rotating around objects behaves a little bit more like other 3D applications
- The cursor changes when dragging files into the window and pressing ALT
- Bugfix: the viewport was reseting it's transformation after resizing the window