### PR TITLE
Add makefile and documentation for building with Mono

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# GNU Make makefile for building with Mono
+# (see README.mono.md)
+
+MONO    = mono
+MSBUILD = msbuild
+
+#CONFIG = Debug
+CONFIG = Release
+
+SPICA_EXE = SPICA.WinForms/bin/$(CONFIG)/SPICA.WinForms.exe
+
+# Note: The Mono compiler seems to dump some detritus by default in
+# /tmp, so we set TMPDIR to a more suitable location
+
+$(SPICA_EXE): SPICA.sln
+	mkdir -p tmp
+	TMPDIR=$(shell pwd)/tmp $(MSBUILD) /p:Configuration=$(CONFIG) $<
+
+install: $(SPICA_EXE)
+	rm -rf spica-install
+	mkdir spica-install
+	cp -np */bin/$(CONFIG)/*.dll spica-install
+	cp -np */bin/$(CONFIG)/*.exe spica-install
+	mv -n spica-install/SPICA.WinForms.exe spica-install/SPICA.exe
+
+run: $(SPICA_EXE)
+	$(MONO) $<
+
+run-install: spica-install/SPICA.exe
+	$(MONO) $<
+
+clean:
+	rm -rf SPICA*/bin SPICA*/obj
+	rm -rf spica-install
+	rm -rf tmp
+
+.PHONY: clean install run run-install
+
+# EOF

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ OpenTK git can be found [here](https://github.com/opentk/opentk).
 
 You will need .NET Framework 4.6 and a GPU capable of OpenGL 3.3 at least.
 
+SPICA can be built on Linux/Mac using [Mono](https://www.mono-project.com/).
+See `README.mono.md` for details.
+
 **Windows build:**
 
 To download the lastest automatic build for Windows, [Click Here](https://ci.appveyor.com/api/projects/gdkchan/spica/artifacts/spica_lastest.zip).

--- a/README.mono.md
+++ b/README.mono.md
@@ -1,0 +1,44 @@
+# Building SPICA with Mono
+
+SPICA can be built and run using the
+[Mono](https://www.mono-project.com/) toolchain. This allows SPICA to be
+used on GNU/Linux, MacOS X, and possibly other platforms.
+
+This build has been tested using Mono 5.12.0 on Ubuntu Linux for amd64.
+
+## Debian/Ubuntu Linux
+
+Note: As of this writing, these distributions ship Mono 4.6, which
+**cannot** compile SPICA. If a newer version is not available, then you
+will need to install from the [Mono Project
+repository](https://www.mono-project.com/download/stable/#download-lin).
+Also, the `libopentk1.1-cil` package provided by the distribution is too
+old to be of use.
+
+Install the `mono-devel` package if you don't already have it.
+
+SPICA requires [OpenTK](https://opentk.github.io/). A compatible
+pre-compiled version is provided in the `Libraries` subdirectory. If you
+prefer to use your own build, replace the appropriate files therein.
+
+Then, in a shell in the top-level directory of the SPICA source tree, run
+```
+$ make
+```
+If compilation succeeds, you can start the program with
+```
+$ make run
+```
+Finally, you can clear out the build with
+```
+$ make clean
+```
+Additional targets and options may be reviewed in the `Makefile`.
+
+## CentOS/Fedora Linux
+
+TODO (contributions welcome)
+
+## MacOS X
+
+TODO (contributions welcome)


### PR DESCRIPTION
Hi @gdkchan, I found that it is possible to compile/run SPICA from source on Linux using Mono. There is no documentation on doing this, however, so this PR adds that, plus a makefile to simplify the process.

In your original VG-Resource forum post on SPICA, you mentioned that you wanted to move away from WinForms to something that was more cross-platform compatible. Well, as it turns out, Mono has a (seemingly) complete implementation of WinForms. So for the sake of Linux and MacOS X compatibility, there does not appear to be a need to move to a different GUI toolkit. (I do appreciate your concern for cross-platform support, and likewise previously believed that WinForms was Windows-only.)

I've tested this build on my own setup, which is Ubuntu Linux (bionic/18.04) on amd64. Others will need to contribute details on what is different about building on CentOS/Fedora/etc. and MacOS X.