### PR TITLE
fixed a missing declaration in FragmentShaderBase

### DIFF
--- a/SPICA.Rendering/Resources/FragmentShaderBase.txt
+++ b/SPICA.Rendering/Resources/FragmentShaderBase.txt
@@ -1,4 +1,5 @@
 #version 150
+#extension GL_ARB_gpu_shader5 : require
 
 uniform sampler2D LUTs[6];
 


### PR DESCRIPTION
Based on the patch here: https://github.com/gdkchan/SPICA/issues/47. I think it is important to have a good default that build. The question is: does it work for other's computer ? I think it should. It is specified here: https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_gpu_shader5.txt . I have no idea why it work with driver, and not some other, but it is probably applied by default by some. It may however require more testing with other driver. It work for me, however.