### PR TITLE
Makefile: Add Fix For Folder That Contains Spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SPICA_EXE = SPICA.WinForms/bin/$(CONFIG)/SPICA.WinForms.exe
 
 $(SPICA_EXE): SPICA.sln
 	mkdir -p tmp
-	TMPDIR=$(shell pwd)/tmp $(MSBUILD) /p:Configuration=$(CONFIG) $<
+	TMPDIR=$(pwd)/tmp $(MSBUILD) /p:Configuration=$(CONFIG) $<
 
 install: $(SPICA_EXE)
 	rm -rf spica-install


### PR DESCRIPTION
Using `shell pwd` seems to cause the Makefile to fail on my Fedora, since I have spaces on one of my folders. I removed the `shell` part from the command.